### PR TITLE
Move ember-compatibility-helpers to devDependencies

### DIFF
--- a/addon/modifiers/on-key.js
+++ b/addon/modifiers/on-key.js
@@ -1,125 +1,111 @@
 import Modifier from 'ember-modifier';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
-import { gte } from 'ember-compatibility-helpers';
 import listenerName from 'ember-keyboard/utils/listener-name';
 import isKey from 'ember-keyboard/utils/is-key';
 
 const ONLY_WHEN_FOCUSED_TAG_NAMES = ['input', 'select', 'textarea'];
 
-let Klass;
-if (gte('3.8.0')) {
-  /* This is an element modifier to trigger some behavior when
-   * specified key combo is pressed. When used with a form element
-   * (input, textarea, or select), the action fires only when element
-   * has focus. When used with another element type, it will trigger the
-   * passed action, OR if no action is passed, it will trigger a `click`
-   * on the element. This allows for easy declaration of keyboard shortcuts
-   * for anything clickable: In the following example, we trigger a
-   * click on the button when the B key is pressed:
-   *
-   * <button
-   *    type="button"
-   *    {{on-key 'b'}}>
-   *   Click me, or press "B"
-   * </button>
-   */
-  Klass = class OnKeyModifier extends Modifier {
-    @service keyboard;
+/* This is an element modifier to trigger some behavior when
+ * specified key combo is pressed. When used with a form element
+ * (input, textarea, or select), the action fires only when element
+ * has focus. When used with another element type, it will trigger the
+ * passed action, OR if no action is passed, it will trigger a `click`
+ * on the element. This allows for easy declaration of keyboard shortcuts
+ * for anything clickable: In the following example, we trigger a
+ * click on the button when the B key is pressed:
+ *
+ * <button
+ *    type="button"
+ *    {{on-key 'b'}}>
+ *   Click me, or press "B"
+ * </button>
+ */
+export default class OnKeyModifier extends Modifier {
+  @service keyboard;
 
-    keyboardPriority = 0;
-    activatedParamValue = true;
-    eventName = 'keydown';
-    onlyWhenFocused = true;
-    listenerName;
+  keyboardPriority = 0;
+  activatedParamValue = true;
+  eventName = 'keydown';
+  onlyWhenFocused = true;
+  listenerName;
 
-    didReceiveArguments() {
-      let [keyCombo, callback] = this.args.positional;
-      let { activated, event, priority } = this.args.named;
-      this.keyCombo = keyCombo;
-      this.callback = callback;
-      this.eventName = event || 'keydown';
-      this.activatedParamValue = Object.keys(this.args.named).includes(
-        'activated'
-      )
-        ? !!activated
-        : undefined;
-      this.keyboardPriority = priority ? parseInt(priority, 10) : 0;
-      this.listenerName = listenerName(this.eventName, this.keyCombo);
-      if (this.args.named.onlyWhenFocused !== undefined) {
-        this.onlyWhenFocused = this.args.named.onlyWhenFocused;
-      } else {
-        this.onlyWhenFocused = ONLY_WHEN_FOCUSED_TAG_NAMES.includes(
-          this.element.tagName.toLowerCase()
-        );
-      }
-    }
-
-    didInstall() {
-      this.keyboard.register(this);
-      if (this.onlyWhenFocused) {
-        this.element.addEventListener('click', this.onFocus, true);
-        this.element.addEventListener('focus', this.onFocus, true);
-        this.element.addEventListener('focusout', this.onFocusOut, true);
-      }
-    }
-
-    willRemove() {
-      if (this.onlyWhenFocused) {
-        this.element.removeEventListener('click', this.onFocus, true);
-        this.element.removeEventListener('focus', this.onFocus, true);
-        this.element.removeEventListener('focusout', this.onFocusOut, true);
-      }
-      this.keyboard.unregister(this);
-    }
-
-    @action onFocus() {
-      this.isFocused = true;
-    }
-
-    @action onFocusOut() {
-      this.isFocused = false;
-    }
-
-    get keyboardActivated() {
-      if (this.activatedParamValue === false) {
-        return false;
-      }
-      if (this.onlyWhenFocused) {
-        return this.isFocused;
-      }
-      return true;
-    }
-
-    get keyboardFirstResponder() {
-      if (this.onlyWhenFocused) {
-        return this.isFocused;
-      }
-      return false;
-    }
-
-    canHandleKeyboardEvent(event) {
-      return isKey(this.listenerName, event);
-    }
-
-    handleKeyboardEvent(event, ekEvent) {
-      if (isKey(this.listenerName, event)) {
-        if (this.callback) {
-          this.callback(event, ekEvent);
-        } else {
-          this.element.click();
-        }
-      }
-    }
-  };
-} else {
-  Klass = class OnKeyModifier extends Modifier {
-    didInstall() {
-      throw new Error(
-        'ember-keyboard only supports the on-key element modifier in Ember 3.8 and higher.'
+  didReceiveArguments() {
+    let [keyCombo, callback] = this.args.positional;
+    let { activated, event, priority } = this.args.named;
+    this.keyCombo = keyCombo;
+    this.callback = callback;
+    this.eventName = event || 'keydown';
+    this.activatedParamValue = Object.keys(this.args.named).includes(
+      'activated'
+    )
+      ? !!activated
+      : undefined;
+    this.keyboardPriority = priority ? parseInt(priority, 10) : 0;
+    this.listenerName = listenerName(this.eventName, this.keyCombo);
+    if (this.args.named.onlyWhenFocused !== undefined) {
+      this.onlyWhenFocused = this.args.named.onlyWhenFocused;
+    } else {
+      this.onlyWhenFocused = ONLY_WHEN_FOCUSED_TAG_NAMES.includes(
+        this.element.tagName.toLowerCase()
       );
     }
-  };
-}
+  }
 
-export default Klass;
+  didInstall() {
+    this.keyboard.register(this);
+    if (this.onlyWhenFocused) {
+      this.element.addEventListener('click', this.onFocus, true);
+      this.element.addEventListener('focus', this.onFocus, true);
+      this.element.addEventListener('focusout', this.onFocusOut, true);
+    }
+  }
+
+  willRemove() {
+    if (this.onlyWhenFocused) {
+      this.element.removeEventListener('click', this.onFocus, true);
+      this.element.removeEventListener('focus', this.onFocus, true);
+      this.element.removeEventListener('focusout', this.onFocusOut, true);
+    }
+    this.keyboard.unregister(this);
+  }
+
+  @action onFocus() {
+    this.isFocused = true;
+  }
+
+  @action onFocusOut() {
+    this.isFocused = false;
+  }
+
+  get keyboardActivated() {
+    if (this.activatedParamValue === false) {
+      return false;
+    }
+    if (this.onlyWhenFocused) {
+      return this.isFocused;
+    }
+    return true;
+  }
+
+  get keyboardFirstResponder() {
+    if (this.onlyWhenFocused) {
+      return this.isFocused;
+    }
+    return false;
+  }
+
+  canHandleKeyboardEvent(event) {
+    return isKey(this.listenerName, event);
+  }
+
+  handleKeyboardEvent(event, ekEvent) {
+    if (isKey(this.listenerName, event)) {
+      if (this.callback) {
+        this.callback(event, ekEvent);
+      } else {
+        this.element.click();
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
-    "ember-compatibility-helpers": "^1.2.4",
     "ember-modifier": "^2.1.2 || ^3.0.0",
     "ember-modifier-manager-polyfill": "^1.2.0"
   },
@@ -46,6 +45,7 @@
     "broccoli-asset-rev": "^3.0.0",
     "ember-angle-bracket-invocation-polyfill": "^3.0.1",
     "ember-auto-import": "^2.2.4",
+    "ember-compatibility-helpers": "^1.2.5",
     "ember-cli": "~3.28.4",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-fastboot": "^3.2.0-beta.4",

--- a/tests/acceptance/on-key-modifier-test.js
+++ b/tests/acceptance/on-key-modifier-test.js
@@ -8,144 +8,135 @@ import {
 } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
-import { gte } from 'ember-compatibility-helpers';
 import { textChanged } from '../helpers/text-changed';
 
-if (gte('3.8.0')) {
-  module('Acceptance | ember keyboard | on-key modifier', function (hooks) {
-    setupApplicationTest(hooks);
+module('Acceptance | ember keyboard | on-key modifier', function (hooks) {
+  setupApplicationTest(hooks);
 
-    hooks.beforeEach(async function (assert) {
-      await visit('/test-scenario/on-key-modifier-examples');
+  hooks.beforeEach(async function (assert) {
+    await visit('/test-scenario/on-key-modifier-examples');
 
-      assert.equal(currentURL(), '/test-scenario/on-key-modifier-examples');
-    });
-
-    test('KeyB button shortcut', async function (assert) {
-      assert.expect(3);
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyB', key: 'b' }),
-        {
-          selectorName: 'b-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press triggered',
-        }
-      );
-    });
-
-    test('KeyC button shortcut should only fire when keyboard is activated', async function (assert) {
-      assert.expect(5);
-
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyC', key: 'c' }),
-        {
-          selectorName: 'c-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press not triggered',
-        }
-      );
-
-      await click('[data-test-checkbox]');
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyC', key: 'c' }),
-        {
-          selectorName: 'c-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press triggered',
-        }
-      );
-    });
-
-    test('KeyD button shortcut for keydown should fire', async function (assert) {
-      assert.expect(5);
-
-      await textChanged(
-        assert,
-        () => triggerEvent(document.body, 'keyup', { code: 'KeyD', key: 'd' }),
-        {
-          selectorName: 'd-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press not triggered',
-        }
-      );
-
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyD', key: 'd' }),
-        {
-          selectorName: 'd-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press triggered',
-        }
-      );
-    });
-
-    test('KeyP button shortcut does not block other shortcuts', async function (assert) {
-      assert.expect(5);
-
-      await fillIn('[data-test-priority]', 1);
-
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyD', key: 'd' }),
-        {
-          selectorName: 'd-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press triggered',
-        }
-      );
-
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', { code: 'KeyP', key: 'p' }),
-        {
-          selectorName: 'p-button',
-          beforeValue: 'button press not triggered',
-          afterValue: 'button press triggered',
-        }
-      );
-    });
-
-    test('Enter text input shortcut', async function (assert) {
-      assert.expect(5);
-
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', {
-            code: 'Enter',
-            key: 'Enter',
-          }),
-        {
-          selectorName: 'text-field',
-          beforeValue: 'enter not pressed while input focused',
-          afterValue: 'enter not pressed while input focused',
-        }
-      );
-
-      await focus('input[type="text"]');
-      await textChanged(
-        assert,
-        () =>
-          triggerEvent(document.body, 'keydown', {
-            code: 'Enter',
-            key: 'Enter',
-          }),
-        {
-          selectorName: 'text-field',
-          beforeValue: 'enter not pressed while input focused',
-          afterValue: 'enter pressed while input focused',
-        }
-      );
-    });
+    assert.equal(currentURL(), '/test-scenario/on-key-modifier-examples');
   });
-}
+
+  test('KeyB button shortcut', async function (assert) {
+    assert.expect(3);
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyB', key: 'b' }),
+      {
+        selectorName: 'b-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press triggered',
+      }
+    );
+  });
+
+  test('KeyC button shortcut should only fire when keyboard is activated', async function (assert) {
+    assert.expect(5);
+
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyC', key: 'c' }),
+      {
+        selectorName: 'c-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press not triggered',
+      }
+    );
+
+    await click('[data-test-checkbox]');
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyC', key: 'c' }),
+      {
+        selectorName: 'c-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press triggered',
+      }
+    );
+  });
+
+  test('KeyD button shortcut for keydown should fire', async function (assert) {
+    assert.expect(5);
+
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keyup', { code: 'KeyD', key: 'd' }),
+      {
+        selectorName: 'd-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press not triggered',
+      }
+    );
+
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyD', key: 'd' }),
+      {
+        selectorName: 'd-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press triggered',
+      }
+    );
+  });
+
+  test('KeyP button shortcut does not block other shortcuts', async function (assert) {
+    assert.expect(5);
+
+    await fillIn('[data-test-priority]', 1);
+
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyD', key: 'd' }),
+      {
+        selectorName: 'd-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press triggered',
+      }
+    );
+
+    await textChanged(
+      assert,
+      () => triggerEvent(document.body, 'keydown', { code: 'KeyP', key: 'p' }),
+      {
+        selectorName: 'p-button',
+        beforeValue: 'button press not triggered',
+        afterValue: 'button press triggered',
+      }
+    );
+  });
+
+  test('Enter text input shortcut', async function (assert) {
+    assert.expect(5);
+
+    await textChanged(
+      assert,
+      () =>
+        triggerEvent(document.body, 'keydown', {
+          code: 'Enter',
+          key: 'Enter',
+        }),
+      {
+        selectorName: 'text-field',
+        beforeValue: 'enter not pressed while input focused',
+        afterValue: 'enter not pressed while input focused',
+      }
+    );
+
+    await focus('input[type="text"]');
+    await textChanged(
+      assert,
+      () =>
+        triggerEvent(document.body, 'keydown', {
+          code: 'Enter',
+          key: 'Enter',
+        }),
+      {
+        selectorName: 'text-field',
+        beforeValue: 'enter not pressed while input focused',
+        afterValue: 'enter pressed while input focused',
+      }
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,7 +5561,7 @@ ember-cli@~3.28.4:
     workerpool "^6.1.4"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==


### PR DESCRIPTION
As we explicitly set Ember 3.8 as minimal supported version, there does not seem a need to error about the same and addon can have one less dependency.